### PR TITLE
replacing letter-spacing grid hack

### DIFF
--- a/raw/sass/static/grid.scss
+++ b/raw/sass/static/grid.scss
@@ -34,7 +34,7 @@
 	vertical-align: top;
 	display: inline-block;
 	box-sizing: border-box;
-	margin-right: -.27em;
+	margin-right: -0.27em;
 	white-space: normal;
 	padding-left: $grid-gutter-width;
 }

--- a/raw/sass/static/grid.scss
+++ b/raw/sass/static/grid.scss
@@ -34,7 +34,7 @@
 	vertical-align: top;
 	display: inline-block;
 	box-sizing: border-box;
-	margin-right: -.244em;
+	margin-right: -.27em;
 	white-space: normal;
 	padding-left: $grid-gutter-width;
 }

--- a/raw/sass/static/grid.scss
+++ b/raw/sass/static/grid.scss
@@ -16,7 +16,6 @@
 }
 
 .row {
-	letter-spacing: -0.27em;
 	margin-left: $grid-gutter-width * -1;
 	&.row--reverse {
 		direction: rtl;
@@ -35,7 +34,7 @@
 	vertical-align: top;
 	display: inline-block;
 	box-sizing: border-box;
-	letter-spacing: normal;
+	margin-right: -.244em;
 	white-space: normal;
 	padding-left: $grid-gutter-width;
 }


### PR DESCRIPTION
Now you can change the font-size on high level elements like the body or html without messing up the grid.