### PR TITLE
moved cache directory, readme typo, index_slim.php changes and minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .DS_Store
 
+slim/cache/
 slim/composer.phar
 slim/composer.lock
-slim/templates/__cache/
 slim/vendor/
 
-public_html/assets
+public_html/assets/
 
 node_modules/

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "",
 	"version": "0.0.1",
 	"description": "",
+	"private": true,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ten4design/repo.git"

--- a/public_html/index_slim.php
+++ b/public_html/index_slim.php
@@ -19,7 +19,7 @@ $app = new \Slim\Slim(array(
 $app->view(new \Slim\Views\Twig());
 $app->view->parserOptions = array(
 	'charset' => 'utf-8',
-	'cache' => realpath('../slim/templates/__cache'),
+	'cache' => realpath('../slim/cache'),
 	'auto_reload' => true,
 	'strict_variables' => false,
 	'autoescape' => true

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ When building a site using slim:
 
 	`php composer.phar install`
 
-- ensure that the `slim/cache/` directory can be written to by php scripts
+- create the `slim/cache/` directory and ensure that it can be written to by php scripts
 
 ### Files
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ When building a site using craft:
 	- `_entry.twig` Includes SEO stuff and some examples of macros in use.
 	- `404.twig`
 
+
 ## Slim
 
 When building a site using slim:
@@ -28,13 +29,13 @@ When building a site using slim:
 - remove the craft portion of the `.htaccess` rewrites
 - install composer by running:
 
-`curl -sS https://getcomposer.org/installer | php`
+	`curl -sS https://getcomposer.org/installer | php`
 
 - install slim dependencies by running:
 
-`php composer.phar install`
+	`php composer.phar install`
 
-- ensure that the `app/templates/__cache` directory can be written to by php scripts
+- ensure that the `slim/cache/` directory can be written to by php scripts
 
 ### Files
 


### PR DESCRIPTION
moving cache prevents gulp watching cached templates for changes and limits the templates to twig templates, readme typo and modified index_slim.php to reflect changes