### PR TITLE
Added html and paste as plain text by default

### DIFF
--- a/craft/config/redactor/Standard.json
+++ b/craft/config/redactor/Standard.json
@@ -1,5 +1,6 @@
 {
-	buttons: ['bold','italic','unorderedlist','orderedlist','link'],
+	buttons: ['bold','italic','unorderedlist','orderedlist','link','html'],
 	plugins: ['fullscreen'],
-	toolbarFixed: true
+	toolbarFixed: true,
+	pastePlainText: true,
 }

--- a/craft/config/redactor/Standard.json
+++ b/craft/config/redactor/Standard.json
@@ -2,5 +2,5 @@
 	buttons: ['bold','italic','unorderedlist','orderedlist','link','html'],
 	plugins: ['fullscreen'],
 	toolbarFixed: true,
-	pastePlainText: true,
+	pastePlainText: true
 }


### PR DESCRIPTION
Think we decided that clients DO need html and can be removed if they can't be trusted. Also, paste as plain text is in our test drive so makes sense to include by default.