### PR TITLE
Add single colon pseudo selectors to icon classes for IE8

### DIFF
--- a/raw/sass/site/ie8.scss
+++ b/raw/sass/site/ie8.scss
@@ -4,3 +4,32 @@
 img {
 	width: auto;
 }
+
+.icon {
+	&:before {
+		font-family: $font-icons;
+		vertical-align: middle;
+		speak: none;
+		font-weight: normal;
+		font-style: normal;
+		font-variant: normal;
+		text-transform: none;
+		line-height: 1;
+	}
+	@each $icon in $icon-list {
+		&.#{ nth( $icon, 1 ) }:before {
+			content: '\#{ nth( $icon, 2 ) }';
+		}
+	}
+}
+
+.icon--end {
+	&:after {
+		@extend .icon:before;
+	}
+	@each $icon in $icon-list {
+		&.#{ nth( $icon, 1 ) }:before {
+			content: '';
+		}
+	}
+}


### PR DESCRIPTION
Because we should do it properly for the other browsers as per Andy's say so